### PR TITLE
Fix Build Issues for Using RoboStack's ROS Noetic Environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__
+.vscode/
+build/
+devel/
+logs/
+.catkin*

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ __pycache__
 build/
 devel/
 logs/
-.catkin*
+.catkin_tools

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+# About This Fork
+
+This fork supports building and testing using a ROS Noetic Conda install maintained by [Robostack](https://robostack.github.io/GettingStarted.html).
+
+```sh
+mamba install ros-noetic-desktop-full=1.5.0 -c robostack-staging -y
+
+mamba install compilers cmake pkg-config make ninja colcon-common-extensions catkin_tools -y
+
+mamba install ompl=1.5.2 armadillo=12.6.5 -y
+```
+
+Now you can use it on whatever distro you like (Ubuntu Jammy is tested). See commits to find out what changes have been made. The original README is kept below, enjoy!
+
 # EGO-Planner-v2
 Swarm Playground, the codebase of the paper "[Swarm of micro flying robots in the wild](https://www.science.org/doi/10.1126/scirobotics.abm5954)".
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Swarm Playground, the codebase of the paper "[Swarm of micro flying robots in th
 
 Please follow the [tutorial PDF file](swarm-playground/[README]_Brief_Documentation_for_Swarm_Playground.pdf) with corresponding videos ([1](swarm-playground/main_ws/WatchMe_main.mp4), [2](swarm-playground/formation_ws/WatchMe_formation.mp4), [3](swarm-playground/tracking_ws/WatchMe_tracking.mp4), [4](swarm-playground/interlaced_flight_ws/WatchMe_interlaced_flights.mp4)) to run the code.
 
+For Ubuntu 22 (or other distros) users, a quick way to get started is to use [RoboStack](https://robostack.github.io/GettingStarted.html)'s ROS Noetic in the Conda virtual environment. Instructions can be found [here](./swarm-playground/[README]_Addtional_Instructions_for_Ubuntu22.md).
+
 This work was born out of [MINCO](https://github.com/ZJU-FAST-Lab/GCOPTER).
 If you find it interesting, please give both repos stars generously. Thanks.
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,3 @@
-# About This Fork
-
-This fork supports building and testing using a ROS Noetic Conda install maintained by [Robostack](https://robostack.github.io/GettingStarted.html).
-
-```sh
-mamba install ros-noetic-desktop-full=1.5.0 -c robostack-staging -y
-
-mamba install compilers cmake pkg-config make ninja colcon-common-extensions catkin_tools -y
-
-mamba install ompl=1.5.2 armadillo=12.6.5 -y
-```
-
-Now you can use it on whatever distro you like (Ubuntu Jammy is tested). See commits to find out what changes have been made. The original README is kept below, enjoy!
-
 # EGO-Planner-v2
 Swarm Playground, the codebase of the paper "[Swarm of micro flying robots in the wild](https://www.science.org/doi/10.1126/scirobotics.abm5954)".
 

--- a/swarm-playground/[README]_Addtional_Instructions_for_Ubuntu22.md
+++ b/swarm-playground/[README]_Addtional_Instructions_for_Ubuntu22.md
@@ -1,0 +1,18 @@
+# Getting Started with "Conda ROS"
+
+First please install `mamba`, which is a faster version of `conda` and defaults to the `conda-forge` channel. Then you can run the following to set up the environment.
+
+```sh
+mamba create -n ego-v2 python=3.9 -y
+mamba activate ego-v2
+
+mamba install ros-noetic-desktop-full=1.5.0 -c robostack-staging -y
+mamba install compilers cmake pkg-config make ninja colcon-common-extensions catkin_tools -y
+mamba install armadillo=12.6.5 -y
+
+# reactivate the env to prevent permission issues
+mamba deactivate
+mamba activate ego-v2
+```
+
+With this environment activated you can run ROS commands as normal. For further instructions please refer to the [tutorial pdf](./[README]_Brief_Documentation_for_Swarm_Playground.pdf).

--- a/swarm-playground/formation_ws/src/CMakeLists.txt
+++ b/swarm-playground/formation_ws/src/CMakeLists.txt
@@ -1,1 +1,0 @@
-/home/ryan/mambaforge/envs/dhma/share/catkin/cmake/toplevel.cmake

--- a/swarm-playground/formation_ws/src/CMakeLists.txt
+++ b/swarm-playground/formation_ws/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/noetic/share/catkin/cmake/toplevel.cmake
+/home/ryan/mambaforge/envs/dhma/share/catkin/cmake/toplevel.cmake

--- a/swarm-playground/formation_ws/src/Utils/odom_visualization/CMakeLists.txt
+++ b/swarm-playground/formation_ws/src/Utils/odom_visualization/CMakeLists.txt
@@ -37,7 +37,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(odom_visualization)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-O3 -Wall -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -g")
 ADD_COMPILE_OPTIONS(-std=c++11 )
 ADD_COMPILE_OPTIONS(-std=c++14 )
 

--- a/swarm-playground/formation_ws/src/Utils/pose_utils/CMakeLists.txt
+++ b/swarm-playground/formation_ws/src/Utils/pose_utils/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(pose_utils)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-O3 -Wall -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -g")
 ADD_COMPILE_OPTIONS(-std=c++11 )
 ADD_COMPILE_OPTIONS(-std=c++14 )
 

--- a/swarm-playground/formation_ws/src/Utils/rviz_plugins/CMakeLists.txt
+++ b/swarm-playground/formation_ws/src/Utils/rviz_plugins/CMakeLists.txt
@@ -21,7 +21,7 @@ catkin_package(
 
 if(rviz_QT_VERSION VERSION_LESS "5")
   message(STATUS "Using Qt4 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-  find_package(Qt4 ${rviz_QT_VERSION} EXACT REQUIRED QtCore QtGui)
+  find_package(Qt4 ${rviz_QT_VERSION} REQUIRED QtCore QtGui)
   ## pull in all required include dirs, define QT_LIBRARIES, etc.
   include(${QT_USE_FILE})
   qt4_wrap_cpp(MOC_FILES
@@ -30,7 +30,7 @@ if(rviz_QT_VERSION VERSION_LESS "5")
 
 else()
   message(STATUS "Using Qt5 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-  find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+  find_package(Qt5 ${rviz_QT_VERSION} REQUIRED Core Widgets)
   ## make target_link_libraries(${QT_LIBRARIES}) pull in all required dependencies
   set(QT_LIBRARIES Qt5::Widgets)
   qt5_wrap_cpp(MOC_FILES

--- a/swarm-playground/formation_ws/src/planner/swarm_bridge/CMakeLists.txt
+++ b/swarm-playground/formation_ws/src/planner/swarm_bridge/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(Eigen3 REQUIRED)
 
 set(ENABLE_TCP false) # requires zmq, zmqpp 
 
+find_package(Boost REQUIRED COMPONENTS system filesystem thread)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
@@ -35,6 +36,7 @@ add_executable(bridge_node_udp
   )
 target_link_libraries(bridge_node_udp 
   ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
   )
 
 if(ENABLE_TCP)
@@ -46,6 +48,7 @@ if(ENABLE_TCP)
     ${catkin_LIBRARIES}
     zmq
     zmqpp
+    ${Boost_LIBRARIES}
     )
 
 endif(ENABLE_TCP)
@@ -55,6 +58,7 @@ add_executable(traj2odom_node
   )
 target_link_libraries(traj2odom_node 
   ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
   )
 
 

--- a/swarm-playground/formation_ws/src/planner/traj_utils/CMakeLists.txt
+++ b/swarm-playground/formation_ws/src/planner/traj_utils/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(traj_utils)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 # set(ENABLE_PRECOMPILED_HEADERS "OFF")
 

--- a/swarm-playground/formation_ws/src/uav_simulator/local_sensing/CMakeLists.txt
+++ b/swarm-playground/formation_ws/src/uav_simulator/local_sensing/CMakeLists.txt
@@ -65,6 +65,7 @@ if(ENABLE_CUDA)
     ${catkin_LIBRARIES}
   )
 else(ENABLE_CUDA)
+  find_package(PCL REQUIRED)
   find_package(Eigen3 REQUIRED)
   find_package(catkin REQUIRED COMPONENTS
       roscpp roslib cmake_modules pcl_ros sensor_msgs geometry_msgs nav_msgs quadrotor_msgs)

--- a/swarm-playground/formation_ws/src/uav_simulator/mockamap/CMakeLists.txt
+++ b/swarm-playground/formation_ws/src/uav_simulator/mockamap/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
+find_package(PCL REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   pcl_ros
@@ -156,6 +157,7 @@ add_executable(${PROJECT_NAME}_node
 ## Specify libraries to link a library or executable target against
  target_link_libraries(${PROJECT_NAME}_node
    ${catkin_LIBRARIES}
+   ${PCL_LIBRARIES}
  )
 
 #############

--- a/swarm-playground/formation_ws/src/uav_simulator/mockamap/include/maps.hpp
+++ b/swarm-playground/formation_ws/src/uav_simulator/mockamap/include/maps.hpp
@@ -1,6 +1,7 @@
 #ifndef MAPS_HPP
 #define MAPS_HPP
 
+#include <deque>
 #include <ros/ros.h>
 
 #include <pcl/point_cloud.h>

--- a/swarm-playground/formation_ws/src/uav_simulator/so3_control/CMakeLists.txt
+++ b/swarm-playground/formation_ws/src/uav_simulator/so3_control/CMakeLists.txt
@@ -46,7 +46,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(so3_control)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 
 ## Find catkin macros and libraries

--- a/swarm-playground/formation_ws/src/uav_simulator/so3_quadrotor_simulator/CMakeLists.txt
+++ b/swarm-playground/formation_ws/src/uav_simulator/so3_quadrotor_simulator/CMakeLists.txt
@@ -4,7 +4,7 @@ project(so3_quadrotor_simulator)
 add_compile_options(-std=c++11)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 
 find_package(catkin REQUIRED COMPONENTS

--- a/swarm-playground/interlaced_flight_ws/src/CMakeLists.txt
+++ b/swarm-playground/interlaced_flight_ws/src/CMakeLists.txt
@@ -1,1 +1,0 @@
-/home/ryan/mambaforge/envs/dhma/share/catkin/cmake/toplevel.cmake

--- a/swarm-playground/interlaced_flight_ws/src/CMakeLists.txt
+++ b/swarm-playground/interlaced_flight_ws/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/noetic/share/catkin/cmake/toplevel.cmake
+/home/ryan/mambaforge/envs/dhma/share/catkin/cmake/toplevel.cmake

--- a/swarm-playground/interlaced_flight_ws/src/Utils/odom_visualization/CMakeLists.txt
+++ b/swarm-playground/interlaced_flight_ws/src/Utils/odom_visualization/CMakeLists.txt
@@ -37,7 +37,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(odom_visualization)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-O3 -Wall -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -g")
 ADD_COMPILE_OPTIONS(-std=c++11 )
 ADD_COMPILE_OPTIONS(-std=c++14 )
 

--- a/swarm-playground/interlaced_flight_ws/src/Utils/pose_utils/CMakeLists.txt
+++ b/swarm-playground/interlaced_flight_ws/src/Utils/pose_utils/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(pose_utils)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-O3 -Wall -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -g")
 ADD_COMPILE_OPTIONS(-std=c++11 )
 ADD_COMPILE_OPTIONS(-std=c++14 )
 

--- a/swarm-playground/interlaced_flight_ws/src/Utils/rviz_plugins/CMakeLists.txt
+++ b/swarm-playground/interlaced_flight_ws/src/Utils/rviz_plugins/CMakeLists.txt
@@ -22,7 +22,7 @@ catkin_package(
 
 if(rviz_QT_VERSION VERSION_LESS "5")
   message(STATUS "Using Qt4 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-  find_package(Qt4 ${rviz_QT_VERSION} EXACT REQUIRED QtCore QtGui)
+  find_package(Qt4 ${rviz_QT_VERSION} REQUIRED QtCore QtGui)
   ## pull in all required include dirs, define QT_LIBRARIES, etc.
   include(${QT_USE_FILE})
   qt4_wrap_cpp(MOC_FILES
@@ -31,7 +31,7 @@ if(rviz_QT_VERSION VERSION_LESS "5")
 
 else()
   message(STATUS "Using Qt5 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-  find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+  find_package(Qt5 ${rviz_QT_VERSION} REQUIRED Core Widgets)
   ## make target_link_libraries(${QT_LIBRARIES}) pull in all required dependencies
   set(QT_LIBRARIES Qt5::Widgets)
   qt5_wrap_cpp(MOC_FILES

--- a/swarm-playground/interlaced_flight_ws/src/Utils/selected_points_publisher-master/CMakeLists.txt
+++ b/swarm-playground/interlaced_flight_ws/src/Utils/selected_points_publisher-master/CMakeLists.txt
@@ -6,7 +6,7 @@ catkin_package()
 include_directories(include ${catkin_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
-find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets Quick)
+find_package(Qt5 ${rviz_QT_VERSION} REQUIRED Core Widgets Quick)
 set(QT_LIBRARIES Qt5::Widgets)
 qt5_wrap_cpp(MOC_FILES
   include/selected_points_publisher/selected_points_publisher.hpp

--- a/swarm-playground/interlaced_flight_ws/src/planner/swarm_bridge/CMakeLists.txt
+++ b/swarm-playground/interlaced_flight_ws/src/planner/swarm_bridge/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(Eigen3 REQUIRED)
 
 set(ENABLE_TCP false) # requires zmq, zmqpp 
 
+find_package(Boost REQUIRED COMPONENTS system filesystem thread)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
@@ -35,6 +36,7 @@ add_executable(bridge_node_udp
   )
 target_link_libraries(bridge_node_udp 
   ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
   )
 
 if(ENABLE_TCP)
@@ -46,6 +48,7 @@ if(ENABLE_TCP)
     ${catkin_LIBRARIES}
     zmq
     zmqpp
+    ${Boost_LIBRARIES}
     )
 
 endif(ENABLE_TCP)
@@ -55,6 +58,7 @@ add_executable(traj2odom_node
   )
 target_link_libraries(traj2odom_node 
   ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
   )
 
 

--- a/swarm-playground/interlaced_flight_ws/src/planner/traj_utils/CMakeLists.txt
+++ b/swarm-playground/interlaced_flight_ws/src/planner/traj_utils/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(traj_utils)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 # set(ENABLE_PRECOMPILED_HEADERS "OFF")
 

--- a/swarm-playground/interlaced_flight_ws/src/uav_simulator/local_sensing/CMakeLists.txt
+++ b/swarm-playground/interlaced_flight_ws/src/uav_simulator/local_sensing/CMakeLists.txt
@@ -65,6 +65,7 @@ if(ENABLE_CUDA)
     ${catkin_LIBRARIES}
   )
 else(ENABLE_CUDA)
+  find_package(PCL REQUIRED)
   find_package(Eigen3 REQUIRED)
   find_package(catkin REQUIRED COMPONENTS
       roscpp roslib cmake_modules pcl_ros sensor_msgs geometry_msgs nav_msgs quadrotor_msgs)

--- a/swarm-playground/interlaced_flight_ws/src/uav_simulator/mockamap/CMakeLists.txt
+++ b/swarm-playground/interlaced_flight_ws/src/uav_simulator/mockamap/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
+find_package(PCL REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   pcl_ros
@@ -156,6 +157,7 @@ add_executable(${PROJECT_NAME}_node
 ## Specify libraries to link a library or executable target against
  target_link_libraries(${PROJECT_NAME}_node
    ${catkin_LIBRARIES}
+   ${PCL_LIBRARIES}
  )
 
 #############

--- a/swarm-playground/interlaced_flight_ws/src/uav_simulator/mockamap/include/maps.hpp
+++ b/swarm-playground/interlaced_flight_ws/src/uav_simulator/mockamap/include/maps.hpp
@@ -1,6 +1,7 @@
 #ifndef MAPS_HPP
 #define MAPS_HPP
 
+#include <deque>
 #include <ros/ros.h>
 
 #include <pcl/point_cloud.h>

--- a/swarm-playground/interlaced_flight_ws/src/uav_simulator/so3_control/CMakeLists.txt
+++ b/swarm-playground/interlaced_flight_ws/src/uav_simulator/so3_control/CMakeLists.txt
@@ -46,7 +46,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(so3_control)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 
 ## Find catkin macros and libraries

--- a/swarm-playground/interlaced_flight_ws/src/uav_simulator/so3_quadrotor_simulator/CMakeLists.txt
+++ b/swarm-playground/interlaced_flight_ws/src/uav_simulator/so3_quadrotor_simulator/CMakeLists.txt
@@ -4,7 +4,7 @@ project(so3_quadrotor_simulator)
 add_compile_options(-std=c++11)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 
 find_package(catkin REQUIRED COMPONENTS

--- a/swarm-playground/main_ws/src/CMakeLists.txt
+++ b/swarm-playground/main_ws/src/CMakeLists.txt
@@ -1,1 +1,0 @@
-/home/ryan/mambaforge/envs/dhma/share/catkin/cmake/toplevel.cmake

--- a/swarm-playground/main_ws/src/CMakeLists.txt
+++ b/swarm-playground/main_ws/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/noetic/share/catkin/cmake/toplevel.cmake
+/home/ryan/mambaforge/envs/dhma/share/catkin/cmake/toplevel.cmake

--- a/swarm-playground/main_ws/src/Utils/odom_visualization/CMakeLists.txt
+++ b/swarm-playground/main_ws/src/Utils/odom_visualization/CMakeLists.txt
@@ -37,7 +37,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(odom_visualization)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-O3 -Wall -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -g")
 ADD_COMPILE_OPTIONS(-std=c++11 )
 ADD_COMPILE_OPTIONS(-std=c++14 )
 

--- a/swarm-playground/main_ws/src/Utils/pose_utils/CMakeLists.txt
+++ b/swarm-playground/main_ws/src/Utils/pose_utils/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(pose_utils)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-O3 -Wall -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -g")
 ADD_COMPILE_OPTIONS(-std=c++11 )
 ADD_COMPILE_OPTIONS(-std=c++14 )
 

--- a/swarm-playground/main_ws/src/Utils/rviz_plugins/CMakeLists.txt
+++ b/swarm-playground/main_ws/src/Utils/rviz_plugins/CMakeLists.txt
@@ -22,7 +22,7 @@ catkin_package(
 
 if(rviz_QT_VERSION VERSION_LESS "5")
   message(STATUS "Using Qt4 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-  find_package(Qt4 ${rviz_QT_VERSION} EXACT REQUIRED QtCore QtGui)
+  find_package(Qt4 ${rviz_QT_VERSION} REQUIRED QtCore QtGui)
   ## pull in all required include dirs, define QT_LIBRARIES, etc.
   include(${QT_USE_FILE})
   qt4_wrap_cpp(MOC_FILES
@@ -31,7 +31,7 @@ if(rviz_QT_VERSION VERSION_LESS "5")
 
 else()
   message(STATUS "Using Qt5 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-  find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+  find_package(Qt5 ${rviz_QT_VERSION} REQUIRED Core Widgets)
   ## make target_link_libraries(${QT_LIBRARIES}) pull in all required dependencies
   set(QT_LIBRARIES Qt5::Widgets)
   qt5_wrap_cpp(MOC_FILES

--- a/swarm-playground/main_ws/src/Utils/selected_points_publisher/CMakeLists.txt
+++ b/swarm-playground/main_ws/src/Utils/selected_points_publisher/CMakeLists.txt
@@ -6,7 +6,7 @@ catkin_package()
 include_directories(include ${catkin_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
-find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets Quick)
+find_package(Qt5 ${rviz_QT_VERSION} REQUIRED Core Widgets Quick)
 set(QT_LIBRARIES Qt5::Widgets)
 qt5_wrap_cpp(MOC_FILES
   include/selected_points_publisher/selected_points_publisher.hpp

--- a/swarm-playground/main_ws/src/planner/swarm_bridge/CMakeLists.txt
+++ b/swarm-playground/main_ws/src/planner/swarm_bridge/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(Eigen3 REQUIRED)
 
 set(ENABLE_TCP false) # requires zmq, zmqpp 
 
+find_package(Boost REQUIRED COMPONENTS system filesystem thread)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
@@ -35,6 +36,7 @@ add_executable(bridge_node_udp
   )
 target_link_libraries(bridge_node_udp 
   ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
   )
 
 if(ENABLE_TCP)
@@ -46,6 +48,7 @@ if(ENABLE_TCP)
     ${catkin_LIBRARIES}
     zmq
     zmqpp
+    ${Boost_LIBRARIES}
     )
 
 endif(ENABLE_TCP)
@@ -55,6 +58,7 @@ add_executable(traj2odom_node
   )
 target_link_libraries(traj2odom_node 
   ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
   )
 
 

--- a/swarm-playground/main_ws/src/planner/traj_utils/CMakeLists.txt
+++ b/swarm-playground/main_ws/src/planner/traj_utils/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(traj_utils)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 # set(ENABLE_PRECOMPILED_HEADERS "OFF")
 

--- a/swarm-playground/main_ws/src/uav_simulator/local_sensing/CMakeLists.txt
+++ b/swarm-playground/main_ws/src/uav_simulator/local_sensing/CMakeLists.txt
@@ -65,6 +65,7 @@ if(ENABLE_CUDA)
     ${catkin_LIBRARIES}
   )
 else(ENABLE_CUDA)
+  find_package(PCL REQUIRED)
   find_package(Eigen3 REQUIRED)
   find_package(catkin REQUIRED COMPONENTS
       roscpp roslib cmake_modules pcl_ros sensor_msgs geometry_msgs nav_msgs quadrotor_msgs)

--- a/swarm-playground/main_ws/src/uav_simulator/mockamap/CMakeLists.txt
+++ b/swarm-playground/main_ws/src/uav_simulator/mockamap/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
+find_package(PCL REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   pcl_ros
@@ -156,6 +157,7 @@ add_executable(${PROJECT_NAME}_node
 ## Specify libraries to link a library or executable target against
  target_link_libraries(${PROJECT_NAME}_node
    ${catkin_LIBRARIES}
+   ${PCL_LIBRARIES}
  )
 
 #############

--- a/swarm-playground/main_ws/src/uav_simulator/mockamap/include/maps.hpp
+++ b/swarm-playground/main_ws/src/uav_simulator/mockamap/include/maps.hpp
@@ -1,6 +1,7 @@
 #ifndef MAPS_HPP
 #define MAPS_HPP
 
+#include <deque>
 #include <ros/ros.h>
 
 #include <pcl/point_cloud.h>

--- a/swarm-playground/main_ws/src/uav_simulator/so3_control/CMakeLists.txt
+++ b/swarm-playground/main_ws/src/uav_simulator/so3_control/CMakeLists.txt
@@ -46,7 +46,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(so3_control)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 
 ## Find catkin macros and libraries

--- a/swarm-playground/main_ws/src/uav_simulator/so3_quadrotor_simulator/CMakeLists.txt
+++ b/swarm-playground/main_ws/src/uav_simulator/so3_quadrotor_simulator/CMakeLists.txt
@@ -4,7 +4,7 @@ project(so3_quadrotor_simulator)
 add_compile_options(-std=c++11)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 
 find_package(catkin REQUIRED COMPONENTS

--- a/swarm-playground/tracking_ws/src/CMakeLists.txt
+++ b/swarm-playground/tracking_ws/src/CMakeLists.txt
@@ -1,1 +1,0 @@
-/home/ryan/mambaforge/envs/dhma/share/catkin/cmake/toplevel.cmake

--- a/swarm-playground/tracking_ws/src/CMakeLists.txt
+++ b/swarm-playground/tracking_ws/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/noetic/share/catkin/cmake/toplevel.cmake
+/home/ryan/mambaforge/envs/dhma/share/catkin/cmake/toplevel.cmake

--- a/swarm-playground/tracking_ws/src/Utils/odom_visualization/CMakeLists.txt
+++ b/swarm-playground/tracking_ws/src/Utils/odom_visualization/CMakeLists.txt
@@ -37,7 +37,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(odom_visualization)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-O3 -Wall -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -g")
 ADD_COMPILE_OPTIONS(-std=c++11 )
 ADD_COMPILE_OPTIONS(-std=c++14 )
 

--- a/swarm-playground/tracking_ws/src/Utils/pose_utils/CMakeLists.txt
+++ b/swarm-playground/tracking_ws/src/Utils/pose_utils/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(pose_utils)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-O3 -Wall -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -g")
 ADD_COMPILE_OPTIONS(-std=c++11 )
 ADD_COMPILE_OPTIONS(-std=c++14 )
 

--- a/swarm-playground/tracking_ws/src/Utils/rviz_plugins/CMakeLists.txt
+++ b/swarm-playground/tracking_ws/src/Utils/rviz_plugins/CMakeLists.txt
@@ -22,7 +22,7 @@ catkin_package(
 
 if(rviz_QT_VERSION VERSION_LESS "5")
   message(STATUS "Using Qt4 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-  find_package(Qt4 ${rviz_QT_VERSION} EXACT REQUIRED QtCore QtGui)
+  find_package(Qt4 ${rviz_QT_VERSION} REQUIRED QtCore QtGui)
   ## pull in all required include dirs, define QT_LIBRARIES, etc.
   include(${QT_USE_FILE})
   qt4_wrap_cpp(MOC_FILES
@@ -31,7 +31,7 @@ if(rviz_QT_VERSION VERSION_LESS "5")
 
 else()
   message(STATUS "Using Qt5 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-  find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+  find_package(Qt5 ${rviz_QT_VERSION} REQUIRED Core Widgets)
   ## make target_link_libraries(${QT_LIBRARIES}) pull in all required dependencies
   set(QT_LIBRARIES Qt5::Widgets)
   qt5_wrap_cpp(MOC_FILES

--- a/swarm-playground/tracking_ws/src/planner/swarm_bridge/CMakeLists.txt
+++ b/swarm-playground/tracking_ws/src/planner/swarm_bridge/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(Eigen3 REQUIRED)
 
 set(ENABLE_TCP false) # requires zmq, zmqpp 
 
+find_package(Boost REQUIRED COMPONENTS system filesystem thread)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
@@ -35,6 +36,7 @@ add_executable(bridge_node_udp
   )
 target_link_libraries(bridge_node_udp 
   ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
   )
 
 if(ENABLE_TCP)
@@ -46,6 +48,7 @@ if(ENABLE_TCP)
     ${catkin_LIBRARIES}
     zmq
     zmqpp
+    ${Boost_LIBRARIES}
     )
 
 endif(ENABLE_TCP)
@@ -55,6 +58,7 @@ add_executable(traj2odom_node
   )
 target_link_libraries(traj2odom_node 
   ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
   )
 
 

--- a/swarm-playground/tracking_ws/src/planner/traj_utils/CMakeLists.txt
+++ b/swarm-playground/tracking_ws/src/planner/traj_utils/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(traj_utils)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 # set(ENABLE_PRECOMPILED_HEADERS "OFF")
 

--- a/swarm-playground/tracking_ws/src/uav_simulator/local_sensing/CMakeLists.txt
+++ b/swarm-playground/tracking_ws/src/uav_simulator/local_sensing/CMakeLists.txt
@@ -5,6 +5,7 @@ SET(CMAKE_BUILD_TYPE Release) # Release, RelWithDebInfo
 ADD_COMPILE_OPTIONS(-std=c++11 )
 ADD_COMPILE_OPTIONS(-std=c++14 )
 
+find_package(PCL REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
     roscpp roslib cmake_modules pcl_ros sensor_msgs geometry_msgs nav_msgs quadrotor_msgs)

--- a/swarm-playground/tracking_ws/src/uav_simulator/mockamap/CMakeLists.txt
+++ b/swarm-playground/tracking_ws/src/uav_simulator/mockamap/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
+find_package(PCL REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   pcl_ros
@@ -156,6 +157,7 @@ add_executable(${PROJECT_NAME}_node
 ## Specify libraries to link a library or executable target against
  target_link_libraries(${PROJECT_NAME}_node
    ${catkin_LIBRARIES}
+   ${PCL_LIBRARIES}
  )
 
 #############

--- a/swarm-playground/tracking_ws/src/uav_simulator/mockamap/include/maps.hpp
+++ b/swarm-playground/tracking_ws/src/uav_simulator/mockamap/include/maps.hpp
@@ -1,6 +1,7 @@
 #ifndef MAPS_HPP
 #define MAPS_HPP
 
+#include <deque>
 #include <ros/ros.h>
 
 #include <pcl/point_cloud.h>

--- a/swarm-playground/tracking_ws/src/uav_simulator/so3_control/CMakeLists.txt
+++ b/swarm-playground/tracking_ws/src/uav_simulator/so3_control/CMakeLists.txt
@@ -46,7 +46,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(so3_control)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 
 ## Find catkin macros and libraries

--- a/swarm-playground/tracking_ws/src/uav_simulator/so3_quadrotor_simulator/CMakeLists.txt
+++ b/swarm-playground/tracking_ws/src/uav_simulator/so3_quadrotor_simulator/CMakeLists.txt
@@ -4,7 +4,7 @@ project(so3_quadrotor_simulator)
 add_compile_options(-std=c++11)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
Hi,

I've made minor changes to the `CMakeLists.txt` files, and included deque in `map.hpp` files, to fix building issues that may appear when building this project with RoboStack's ROS Noetic in a virtual environment. I've also added instructions to setup the virtual environment in `README`.

In addition, top-level `CMakeLists.txt`s are deleted as they will be automatically generated upon runnning `catkin_make`. So it is safe to delete them.

These changes have been verified on Ubuntu 22 with virtual env (with `catkin_make` only, `catkin build` still fails) and Ubuntu 20 with system-installed ROS. I hope these changes are helpful for others also running Ubuntu 22 and don't want to build ROS 1 from source.

Cheers~
Ercbunny