### PR TITLE
Fix: Prevent infinite loop that leads to "ran out of pool" error in Astar obstacle checking

### DIFF
--- a/swarm-playground/formation_ws/src/planner/path_searching/src/dyn_a_star.cpp
+++ b/swarm-playground/formation_ws/src/planner/path_searching/src/dyn_a_star.cpp
@@ -127,7 +127,7 @@ bool AStar::ConvertToIndexAndAdjustStartEndPoints(Vector3d start_pt, Vector3d en
                 return false;
             }
 
-            occ = checkOccupancy(Index2Coord(start_idx));
+            occ = checkOccupancy(Index2Coord(end_idx));
             if (occ == -1)
             {
                 ROS_WARN("[Astar] End point outside the map region.");

--- a/swarm-playground/interlaced_flight_ws/src/planner/path_searching/src/dyn_a_star.cpp
+++ b/swarm-playground/interlaced_flight_ws/src/planner/path_searching/src/dyn_a_star.cpp
@@ -127,7 +127,7 @@ bool AStar::ConvertToIndexAndAdjustStartEndPoints(Vector3d start_pt, Vector3d en
                 return false;
             }
 
-            occ = checkOccupancy(Index2Coord(start_idx));
+            occ = checkOccupancy(Index2Coord(end_idx));
             if (occ == -1)
             {
                 ROS_WARN("[Astar] End point outside the map region.");

--- a/swarm-playground/main_ws/src/planner/path_searching/src/dyn_a_star.cpp
+++ b/swarm-playground/main_ws/src/planner/path_searching/src/dyn_a_star.cpp
@@ -127,7 +127,7 @@ bool AStar::ConvertToIndexAndAdjustStartEndPoints(Vector3d start_pt, Vector3d en
                 return false;
             }
 
-            occ = checkOccupancy(Index2Coord(start_idx));
+            occ = checkOccupancy(Index2Coord(end_idx));
             if (occ == -1)
             {
                 ROS_WARN("[Astar] End point outside the map region.");

--- a/swarm-playground/tracking_ws/src/planner/path_searching/src/dyn_a_star.cpp
+++ b/swarm-playground/tracking_ws/src/planner/path_searching/src/dyn_a_star.cpp
@@ -127,7 +127,7 @@ bool AStar::ConvertToIndexAndAdjustStartEndPoints(Vector3d start_pt, Vector3d en
                 return false;
             }
 
-            occ = checkOccupancy(Index2Coord(start_idx));
+            occ = checkOccupancy(Index2Coord(end_idx));
             if (occ == -1)
             {
                 ROS_WARN("[Astar] End point outside the map region.");


### PR DESCRIPTION
-This fix replaces an opaque system crash with a clear, actionable error message, which is the correct intended behavior.

- In the while loop, the code checked `checkOccupancy(Index2Coord(start_idx))` instead of `checkOccupancy(Index2Coord(end_idx))` when adjusting the end point.
- This meant that even if the end point was moved outside the map (where `occ = -1`), the condition `while (checkOccupancy(Index2Coord(end_idx))` would continue because `-1` is truthy in C++ , causing endless adjustments.
- Eventually, this led to an index out of bounds during coordinate conversion Coord2Index, causing "Ran out of pool" error.

-I have tested in tracking_ws. Before the fix, the code would fail with an obscure `ran out of pool`,  which was difficult to trace back to its root cause. After the fix, the function  logging a clear message:  `[Astar] End point outside the map region`. This fix replaces an opaque system crash with a clear, actionable error message, which is the correct intended behavior.


